### PR TITLE
wvtestrun produces nicer and more readable output

### DIFF
--- a/wvtestrun
+++ b/wvtestrun
@@ -29,8 +29,11 @@ if (!$pid) {
 }
 
 my $istty = -t STDOUT && $ENV{'TERM'} ne "dumb";
+my $columns = `tput cols` if ($istty);
+
 my @log = ();
 my ($gpasses, $gfails) = (0,0);
+my $column = 0;
 
 sub bigkill($)
 {
@@ -64,14 +67,17 @@ local $SIG{ALRM} = sub {
     bigkill($pid);
 };
 
-sub colourize($)
+sub colourize($$)
 {
-    my $result = shift;
+    my ($column, $result) = @_;
     my $pass = ($result eq "ok");
 
     if ($istty) {
+	my $dots = $columns - 15 - $column%$columns;
+	$dots += $columns if ($dots < 0);
+	my $leader = "."x$dots;
 	my $colour = $pass ? "\e[32;1m" : "\e[31;1m";
-	return "$colour$result\e[0m";
+	return "$colour$leader $result\e[0m";
     } else {
 	return $result;
     }
@@ -84,18 +90,18 @@ sub mstime($$$)
     my $str = sprintf("%d.%03ds", $ms/1000, $ms % 1000);
 
     if ($istty && $ms > $badtime) {
-        return "\e[31;1m$str\e[0m";
+        return ("\e[31;1m$str\e[0m", length($str));
     } elsif ($istty && $ms > $warntime) {
-        return "\e[33;1m$str\e[0m";
+        return ("\e[33;1m$str\e[0m", length($str));
     } else {
-        return "$str";
+        return ("$str", length($str));
     }
 }
 
 sub resultline($$)
 {
     my ($name, $result) = @_;
-    return sprintf("! %-65s %s", $name, colourize($result));
+    return sprintf("! %s %s", $name, colourize(2+length($name)+1, $result));
 }
 
 my $allstart = time();
@@ -105,7 +111,8 @@ sub endsect()
 {
     $stop = time();
     if ($start) {
-	printf " %s %s\n", mstime($stop - $start, 500, 1000), colourize("ok");
+	my ($time, $timelength) = mstime($stop - $start, 500, 1000);
+	printf " %s %s\n", $time, colourize($column + 2 + $timelength, "ok");
     }
 }
 
@@ -121,7 +128,9 @@ while (<$fh>)
 
 	endsect();
 
-	printf("! %s  %s: ", $file, $sect);
+	my $msg = sprintf("! %s  %s: ", $file, $sect);
+	print $msg;
+	$column = length($msg);
 	@log = ();
 	$start = $stop;
     }
@@ -134,6 +143,7 @@ while (<$fh>)
 
 	if (!$start) {
 	    printf("\n! Startup: ");
+	    $column = 11;
 	    $start = time();
 	}
 
@@ -143,11 +153,13 @@ while (<$fh>)
 	    $gfails++;
 	    if (@log) {
 		print "\n" . join("\n", @log) . "\n";
+		$column = 0;
 		@log = ();
 	    }
 	} else {
 	    $gpasses++;
 	    print ".";
+	    $column++;
 	}
     }
     else


### PR DESCRIPTION
When stdout is a TTY, the results are aligned to the same column and are
proceeded by colorized leaders ("........") to easily find the text
related to the result.

Although this change goes against the basic WvTest principle "Be the
stupidest thing that can possibly work", I find it highly useful.

Previously, the output of

```
$ ./wvtestrun cat sample-ok sample-error
```

looked like this:

```
Testing "all" in cat sample-ok sample-error:
! mytest.t.cc  my ok test function: .. 0.000s ok
! mytest.t.cc  my error test function: .
! mytest.t.cc:432     thing.works()                                 ok
This is just some crap that I printed while counting to 3.
! mytest.t.cc.433     3 < 4                                         FAILED
 0.000s ok

WvTest: 4 tests, 1 failure, total time 0.001s.
```

Now, we get this:

```
Testing "all" in cat sample-ok sample-error:
! mytest.t.cc  my ok test function: .. 0.000s ................... ok
! mytest.t.cc  my error test function: .
! mytest.t.cc:432     thing.works() ............................. ok
This is just some crap that I printed while counting to 3.
! mytest.t.cc.433     3 < 4 ..................................... FAILED
 0.000s ......................................................... ok

WvTest: 4 tests, 1 failure, total time 0.001s.
```

Extra care was taken to properly align the results with all combinations of
line lengths and terminal widths. For example, below is the output for a narrow
terminal.

```
Testing "all" in cat sample-ok sample-error:
! mytest.t.cc  my ok test function: .. 0.000s .........
........................................ ok
! mytest.t.cc  my error test function: .
! mytest.t.cc:432     thing.works() .... ok
This is just some crap that I printed while counting to
 3.
! mytest.t.cc.433     3 < 4 ............ FAILED
 0.000s ................................ ok

WvTest: 4 tests, 1 failure, total time 0.000s.
```
