### PR TITLE
Always check the return values from syscalls.

### DIFF
--- a/c/wvtest.c
+++ b/c/wvtest.c
@@ -208,7 +208,9 @@ int wvtest_run_all(char * const *prefixes)
 	    fflush(stdout);
 
 	    cur->main();
-	    chdir(wd);
+	    if (chdir(wd)) {
+		perror("Unable to change back to original directory");
+	    }
 
 	    new_valgrind_errs = memerrs();
 	    WVPASS(new_valgrind_errs == old_valgrind_errs);

--- a/c/wvtestmain.c
+++ b/c/wvtestmain.c
@@ -87,7 +87,9 @@ int main(int argc, char **argv)
 	if (startfd != endfd)
 	{
 	    sprintf(buf, "ls -l /proc/%d/fd", getpid());
-	    system(buf);
+	    if (system(buf) == -1) {
+		fprintf(stderr, "Unable to list open fds\n");
+	    }
 	}
 #endif
     }

--- a/cpp/wvtest.cc
+++ b/cpp/wvtest.cc
@@ -210,7 +210,9 @@ int WvTest::run_all(const char * const *prefixes)
 	    fflush(stdout);
 
 	    cur->main();
-	    chdir(wd);
+	    if (chdir(wd)) {
+		perror("Unable to change back to original directory");
+	    }
 
 	    new_valgrind_errs = memerrs();
 	    WVPASS(new_valgrind_errs == old_valgrind_errs);

--- a/cpp/wvtestmain.cc
+++ b/cpp/wvtestmain.cc
@@ -87,7 +87,9 @@ int main(int argc, char **argv)
 	if (startfd != endfd)
 	{
 	    sprintf(buf, "ls -l /proc/%d/fd", getpid());
-	    system(buf);
+	    if (system(buf) == -1) {
+		fprintf(stderr, "Unable to list open fds\n");
+	    }
 	}
 #endif
     }


### PR DESCRIPTION
Prevents compiler warnings, e.g. from g++'s -Wunused-result.
